### PR TITLE
Remove escape character from the log

### DIFF
--- a/run-ci.py
+++ b/run-ci.py
@@ -705,7 +705,7 @@ class CheckTestRunner(CiBase):
             raise EndTest
 
         # Remove terminal color macro
-        stdout_clean = re.sub(r"\[\d?\;?\d+m", "", stdout)
+        stdout_clean = re.sub(r"\x1B\[\d?\;?\d+m", "", stdout)
 
         # Save the result to the log file
         self.save_result_log(stdout_clean)


### PR DESCRIPTION
The test results for tester in email contains the control characters and
this patch removes the control character, whic is the escape sequence
character (0x1B).