### PR TITLE
Revert "Blacklist sco-tester"

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -89,6 +89,7 @@ test_list = l2cap-tester,
             bnep-tester,
             mgmt-tester,
             rfcomm-tester,
+            sco-tester,
             smp-tester,
             userchan-tester
 


### PR DESCRIPTION
This reverts commit 953797a8aba43a9f8fa92fe51ef94ee662282242.

The fix is in the kernel and it can be enabled.