### PR TITLE
Fix the gitlint config error due to invalid character

### DIFF
--- a/gitlint
+++ b/gitlint
@@ -48,10 +48,3 @@ min-length=1
 # it in the commit message.
 # files=gitlint/rules.py,README.md
 #
-
-~
-~
-~                                                                                                                                               
-~                                                                                                                                               
-~                                                                                                                                               
-~                                                         


### PR DESCRIPTION
This patch fixes the gitlint config file error:

Error: Source contains parsing errors: '/.gitlint' [line 52]: '~ \n' [line 53]: '~ \n'