### PR TITLE
Disable sanitizer option for test-runner

### DIFF
--- a/run-ci.py
+++ b/run-ci.py
@@ -926,6 +926,7 @@ class TestRunnerSetup(CiBase):
         # Configure BlueZ
         logger.info("Configure the BlueZ source")
         (ret, stdout, stderr) = run_cmd("./bootstrap-configure",
+                                        "--disable-lsan", "--disable-asan",
                                         cwd=bluez_dir)
         if ret:
             logger.error("Unable to configure the bluez")


### PR DESCRIPTION
If the sanitizer option is enabled, the test-runner crash.
The sanitizer option is not relevant to the purpose of running the
test-runner, the sanitizer option can be disabled.