### PR TITLE
gitlint: Add rule to ignore the line starts with Fixes:

### DIFF
--- a/gitlint
+++ b/gitlint
@@ -47,3 +47,5 @@ min-length=1
 # it in the commit message.
 # files=gitlint/rules.py,README.md
 #
+[ignore-body-lines]
+regex=^Fixes:


### PR DESCRIPTION
Fixes: are usally longer than max line length and no need to check.