### PR TITLE
run-ci: Add ISO tester to test list

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -117,6 +117,7 @@ submit_pw = yes
 ; List of test to run. If not defined, it runs all available tests.
 ; Specify the full name of the tester binary in tools folder
 test_list = l2cap-tester,
+            iso-tester,
             bnep-tester,
             mgmt-tester,
             rfcomm-tester,

--- a/run-ci.py
+++ b/run-ci.py
@@ -1085,6 +1085,7 @@ class TestRunnerSetup(CiBase):
         self.submit_pw = config_submit_pw(config, self.name)
 
         default_test_list = ["bnep-tester",
+                             "iso-tester",
                              "l2cap-tester",
                              "mgmt-tester",
                              "rfcomm-tester",


### PR DESCRIPTION
This patch adds iso-tester to test list.